### PR TITLE
Sort aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Aliases
 
   * `Gc` records changes to the repository.
   * `Gca` commits all modified and deleted files.
+  * `Gcf` amends the tip of the current branch reusing the same log message as *HEAD*.
+  * `GcF` amends the tip of the current branch.
   * `Gcm` commits with the given message.
   * `Gco` checks out a branch or paths to the working tree.
   * `GcO` checks out hunks from the index or the tree interactively.
-  * `Gcf` amends the tip of the current branch reusing the same log message as *HEAD*.
-  * `GcF` amends the tip of the current branch.
   * `Gcp` applies changes introduced by existing commits.
   * `GcP` applies changes introduced by existing commits without committing.
   * `Gcr` reverts existing commits by reverting patches and recording new commits.
@@ -45,9 +45,9 @@ Aliases
 
 ### Conflict
 
-  * `GCl` lists unmerged files.
   * `GCa` adds unmerged file contents to the index.
   * `GCe` executes merge-tool on all unmerged files.
+  * `GCl` lists unmerged files.
   * `GCo` checks out our changes for unmerged paths.
   * `GCO` checks out our changes for all unmerged paths.
   * `GCt` checks out their changes for unmerged paths.
@@ -57,11 +57,11 @@ Aliases
 
   * `Gd` displays information about files in the index and the work tree.
   * `Gdc` lists cached files.
-  * `Gdx` lists deleted files.
+  * `Gdi` lists ignored files.
+  * `Gdk` lists killed files.
   * `Gdm` lists modified files.
   * `Gdu` lists untracked files.
-  * `Gdk` lists killed files.
-  * `Gdi` lists ignored files.
+  * `Gdx` lists deleted files.
 
 ### Fetch
 
@@ -84,26 +84,26 @@ Aliases
 
   * `Gia` adds file contents to the index.
   * `GiA` adds file contents to the index interactively.
-  * `Giu` adds file contents to the index (updates only known files).
   * `Gid` displays changes between the index and a named commit (diff).
   * `GiD` displays changes between the index and a named commit (word diff).
   * `Gir` resets the current *HEAD* to the specified state.
   * `GiR` resets the current index interactively.
+  * `Giu` adds file contents to the index (updates only known files).
   * `Gix` removes files/directories from the index (recursively).
   * `GiX` removes files/directories from the index (recursively and forced).
 
 ### Log
 
   * `Gl` displays the log.
-  * `Gls` displays the stats log.
+  * `Glc` displays the commit count for each contributor in descending order.
   * `Gld` displays the diff log.
-  * `Glo` displays the one line log.
-  * `GlO` displays the one line log with authors and dates.
   * `Glg` displays the graph log.
   * `GlG` displays the graph log with authors and dates.
-  * `Glv` displays the log, verifying the GPG signature of commits.
-  * `Glc` displays the commit count for each contributor in descending order.
+  * `Glo` displays the one line log.
+  * `GlO` displays the one line log with authors and dates.
   * `Glr` manages reflog information.
+  * `Gls` displays the stats log.
+  * `Glv` displays the log, verifying the GPG signature of commits.
 
 ### Merge
 
@@ -112,19 +112,19 @@ Aliases
   * `GmC` performs the merge but does not commit.
   * `GmF` creates a merge commit even if the merge could be resolved as a fast-forward.
   * `GmS` commits with GPG signature.
-  * `Gmv` verifies the GPG signature of the tip commit of the side branch being merged.
   * `Gmt` runs the merge conflict resolution tools to resolve conflicts.
+  * `Gmv` verifies the GPG signature of the tip commit of the side branch being merged.
 
 ### Push
 
   * `Gp` updates remote refs along with associated objects.
-  * `Gpf` forces a push safely (with "lease").
-  * `GpF` forces a push.
   * `Gpa` pushes all branches.
   * `GpA` pushes all branches and tags.
-  * `Gpt` pushes all tags.
   * `Gpc` pushes the current branch and adds *origin* as an upstream reference for it.
+  * `Gpf` forces a push safely (with "lease").
+  * `GpF` forces a push.
   * `Gpp` pulls and pushes the current branch from *origin* to *origin*.
+  * `Gpt` pushes all tags.
 
 ### Rebase
 
@@ -138,36 +138,36 @@ Aliases
 ### Remote
 
   * `GR` manages tracked repositories.
-  * `GRl` lists remote names and their URLs.
   * `GRa` adds a new remote.
-  * `GRx` removes a remote.
+  * `GRl` lists remote names and their URLs.
   * `GRm` renames a remote.
-  * `GRu` fetches remotes updates.
   * `GRp` prunes all stale remote tracking branches.
   * `GRs` shows information about a given remote.
+  * `GRu` fetches remotes updates.
+  * `GRx` removes a remote.
 
 ### Stash
 
   * `Gs` stashes the changes of the dirty working directory.
   * `Gsa` applies the changes recorded in a stash to the working directory.
-  * `Gsx` drops a stashed state.
-  * `GsX` drops all the stashed states.
-  * `Gsl` lists stashed states.
   * `Gsd` displays changes between the stash and its original parent.
+  * `Gsl` lists stashed states.
   * `Gsp` removes and applies a single stashed state from the stash list.
   * `Gsr` recovers a given stashed state.
   * `Gss` stashes the working directory changes, including untracked files.
   * `GsS` stashes the working directory changes interactively.
-  * `Gsw` stashes the working directory changes retaining the index.
   * `Gsu` unapplies (reverts) applied changes.
+  * `Gsw` stashes the working directory changes retaining the index.
+  * `Gsx` drops a stashed state.
+  * `GsX` drops all the stashed states.
 
 ### Submodule
 
   * `GS` initializes, updates, or inspects submodules.
   * `GSa` adds given a repository as a submodule.
   * `GSf` evaluates a shell command in each of checked out submodules.
-  * `GSi` initializes submodules.
   * `GSI` initializes and clones submodules recursively.
+  * `GSi` initializes submodules.
   * `GSl` lists the commits of all submodules.
   * `GSm` moves a submodule.
   * `GSs` synchronizes remote URL of submodules to the value specified in `.gitmodules`.
@@ -183,14 +183,14 @@ Aliases
 
 ### Working tree
 
-  * `Gws` displays working-tree status in the short format.
-  * `GwS` displays working-tree status.
+  * `Gwc` cleans untracked files from the working tree (dry-run).
+  * `GwC` cleans untracked files from the working tree.
   * `Gwd` displays changes between the working tree and the index (diff).
   * `GwD` displays changes between the working tree and the index (word diff).
   * `Gwr` resets the current *HEAD* to the specified state, does not touch the index nor the working tree.
   * `GwR` resets the current *HEAD*, index and working tree to the specified state.
-  * `Gwc` cleans untracked files from the working tree (dry-run).
-  * `GwC` cleans untracked files from the working tree.
+  * `Gws` displays working-tree status in the short format.
+  * `GwS` displays working-tree status.
   * `Gwx` removes files from the working tree and from the index recursively.
   * `GwX` removes files from the working tree and from the index recursively and forcefully.
 

--- a/init.zsh
+++ b/init.zsh
@@ -38,11 +38,11 @@ _git_log_oneline_medium_format='%C(bold yellow)%h%C(reset) %<(50,trunc)%s %C(bol
   # Commit (c)
   alias ${gprefix}c='git commit --verbose'
   alias ${gprefix}ca='git commit --verbose --all'
+  alias ${gprefix}cf='git commit --amend --reuse-message HEAD'
+  alias ${gprefix}cF='git commit --verbose --amend'
   alias ${gprefix}cm='git commit --message'
   alias ${gprefix}co='git checkout'
   alias ${gprefix}cO='git checkout --patch'
-  alias ${gprefix}cf='git commit --amend --reuse-message HEAD'
-  alias ${gprefix}cF='git commit --verbose --amend'
   alias ${gprefix}cp='git cherry-pick --ff'
   alias ${gprefix}cP='git cherry-pick --no-commit'
   alias ${gprefix}cr='git revert'
@@ -52,9 +52,9 @@ _git_log_oneline_medium_format='%C(bold yellow)%h%C(reset) %<(50,trunc)%s %C(bol
   alias ${gprefix}cv='git verify-commit'
 
   # Conflict (C)
-  alias ${gprefix}Cl='git --no-pager diff --diff-filter=U --name-only'
   alias ${gprefix}Ca='git add $(gCl)'
   alias ${gprefix}Ce='git mergetool $(gCl)'
+  alias ${gprefix}Cl='git --no-pager diff --diff-filter=U --name-only'
   alias ${gprefix}Co='git checkout --ours --'
   alias ${gprefix}CO='gCo $(gCl)'
   alias ${gprefix}Ct='git checkout --theirs --'
@@ -63,11 +63,11 @@ _git_log_oneline_medium_format='%C(bold yellow)%h%C(reset) %<(50,trunc)%s %C(bol
   # Data (d)
   alias ${gprefix}d='git ls-files'
   alias ${gprefix}dc='git ls-files --cached'
-  alias ${gprefix}dx='git ls-files --deleted'
+  alias ${gprefix}di='git status --porcelain --short --ignored | sed -n "s/^!! //p"'
+  alias ${gprefix}dk='git ls-files --killed'
   alias ${gprefix}dm='git ls-files --modified'
   alias ${gprefix}du='git ls-files --other --exclude-standard'
-  alias ${gprefix}dk='git ls-files --killed'
-  alias ${gprefix}di='git status --porcelain --short --ignored | sed -n "s/^!! //p"'
+  alias ${gprefix}dx='git ls-files --deleted'
 
   # Fetch (f)
   alias ${gprefix}f='git fetch'
@@ -87,25 +87,25 @@ _git_log_oneline_medium_format='%C(bold yellow)%h%C(reset) %<(50,trunc)%s %C(bol
   # Index (i)
   alias ${gprefix}ia='git add'
   alias ${gprefix}iA='git add --patch'
-  alias ${gprefix}iu='git add --update'
   alias ${gprefix}id='git diff --no-ext-diff --cached'
   alias ${gprefix}iD='git diff --no-ext-diff --cached --word-diff'
   alias ${gprefix}ir='git reset'
   alias ${gprefix}iR='git reset --patch'
+  alias ${gprefix}iu='git add --update'
   alias ${gprefix}ix='git rm --cached -r'
   alias ${gprefix}iX='git rm --cached -rf'
 
   # Log (l)
   alias ${gprefix}l='git log --topo-order --pretty=format:"${_git_log_fuller_format}"'
-  alias ${gprefix}ls='git log --topo-order --stat --pretty=format:"${_git_log_fuller_format}"'
+  alias ${gprefix}lc='git shortlog --summary --numbered'
   alias ${gprefix}ld='git log --topo-order --stat --patch --full-diff --pretty=format:"${_git_log_fuller_format}"'
-  alias ${gprefix}lo='git log --topo-order --pretty=format:"${_git_log_oneline_format}"'
-  alias ${gprefix}lO='git log --topo-order --pretty=format:"${_git_log_oneline_medium_format}"'
   alias ${gprefix}lg='git log --graph --pretty=format:"${_git_log_oneline_format}"'
   alias ${gprefix}lG='git log --graph --pretty=format:"${_git_log_oneline_medium_format}"'
-  alias ${gprefix}lv='git log --topo-order --show-signature --pretty=format:"${_git_log_fuller_format}"'
-  alias ${gprefix}lc='git shortlog --summary --numbered'
+  alias ${gprefix}lo='git log --topo-order --pretty=format:"${_git_log_oneline_format}"'
+  alias ${gprefix}lO='git log --topo-order --pretty=format:"${_git_log_oneline_medium_format}"'
   alias ${gprefix}lr='git reflog'
+  alias ${gprefix}ls='git log --topo-order --stat --pretty=format:"${_git_log_fuller_format}"'
+  alias ${gprefix}lv='git log --topo-order --show-signature --pretty=format:"${_git_log_fuller_format}"'
 
   # Merge (m)
   alias ${gprefix}m='git merge'
@@ -113,18 +113,18 @@ _git_log_oneline_medium_format='%C(bold yellow)%h%C(reset) %<(50,trunc)%s %C(bol
   alias ${gprefix}mC='git merge --no-commit'
   alias ${gprefix}mF='git merge --no-ff'
   alias ${gprefix}mS='git merge -S'
-  alias ${gprefix}mv='git merge --verify-signatures'
   alias ${gprefix}mt='git mergetool'
+  alias ${gprefix}mv='git merge --verify-signatures'
 
   # Push (p)
   alias ${gprefix}p='git push'
-  alias ${gprefix}pf='git push --force-with-lease'
-  alias ${gprefix}pF='git push --force'
   alias ${gprefix}pa='git push --all'
   alias ${gprefix}pA='git push --all && git push --tags'
-  alias ${gprefix}pt='git push --tags'
   alias ${gprefix}pc='git push --set-upstream origin "$(git-branch-current 2> /dev/null)"'
+  alias ${gprefix}pf='git push --force-with-lease'
+  alias ${gprefix}pF='git push --force'
   alias ${gprefix}pp='git pull origin "$(git-branch-current 2> /dev/null)" && git push origin "$(git-branch-current 2> /dev/null)"'
+  alias ${gprefix}pt='git push --tags'
 
   # Rebase (r)
   alias ${gprefix}r='git rebase'
@@ -136,27 +136,27 @@ _git_log_oneline_medium_format='%C(bold yellow)%h%C(reset) %<(50,trunc)%s %C(bol
 
   # Remote (R)
   alias ${gprefix}R='git remote'
-  alias ${gprefix}Rl='git remote --verbose'
   alias ${gprefix}Ra='git remote add'
-  alias ${gprefix}Rx='git remote rm'
+  alias ${gprefix}Rl='git remote --verbose'
   alias ${gprefix}Rm='git remote rename'
-  alias ${gprefix}Ru='git remote update'
   alias ${gprefix}Rp='git remote prune'
   alias ${gprefix}Rs='git remote show'
+  alias ${gprefix}Ru='git remote update'
+  alias ${gprefix}Rx='git remote rm'
 
   # Stash (s)
   alias ${gprefix}s='git stash'
   alias ${gprefix}sa='git stash apply'
-  alias ${gprefix}sx='git stash drop'
-  alias ${gprefix}sX='git-stash-clear-interactive'
-  alias ${gprefix}sl='git stash list'
   alias ${gprefix}sd='git stash show --patch --stat'
+  alias ${gprefix}sl='git stash list'
   alias ${gprefix}sp='git stash pop'
   alias ${gprefix}sr='git-stash-recover'
   alias ${gprefix}ss='git stash save --include-untracked'
   alias ${gprefix}sS='git stash save --patch --no-keep-index'
-  alias ${gprefix}sw='git stash save --include-untracked --keep-index'
   alias ${gprefix}su='git stash show --patch | git apply --reverse'
+  alias ${gprefix}sw='git stash save --include-untracked --keep-index'
+  alias ${gprefix}sx='git stash drop'
+  alias ${gprefix}sX='git-stash-clear-interactive'
 
   # Submodule (S)
   alias ${gprefix}S='git submodule'
@@ -177,14 +177,14 @@ _git_log_oneline_medium_format='%C(bold yellow)%h%C(reset) %<(50,trunc)%s %C(bol
   alias ${gprefix}tx='git tag --delete'
 
   # Working tree (w)
-  alias ${gprefix}ws='git status --short'
-  alias ${gprefix}wS='git status'
+  alias ${gprefix}wc='git clean --dry-run'
+  alias ${gprefix}wC='git clean -d --force'
   alias ${gprefix}wd='git diff --no-ext-diff'
   alias ${gprefix}wD='git diff --no-ext-diff --word-diff'
   alias ${gprefix}wr='git reset --soft'
   alias ${gprefix}wR='git reset --hard'
-  alias ${gprefix}wc='git clean --dry-run'
-  alias ${gprefix}wC='git clean -d --force'
+  alias ${gprefix}ws='git status --short'
+  alias ${gprefix}wS='git status'
   alias ${gprefix}wx='git rm -r'
   alias ${gprefix}wX='git rm -rf'
 


### PR DESCRIPTION
This sorts all aliases by their alias. Previously the aliases were
sorted by a mix of alias and git command. Sorting only by alias is
useful when trying to find a new available alias.