### PR TITLE
Add GcA alias for git commit patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Aliases
 
   * `Gc` records changes to the repository.
   * `Gca` commits all modified and deleted files.
+  * `GcA` commits all modified files interactivly.
   * `Gcm` commits with the given message.
   * `Gco` checks out a branch or paths to the working tree.
   * `GcO` checks out hunks from the index or the tree interactively.

--- a/init.zsh
+++ b/init.zsh
@@ -38,8 +38,8 @@ _git_log_oneline_medium_format='%C(bold yellow)%h%C(reset) %<(50,trunc)%s %C(bol
   # Commit (c)
   alias ${gprefix}c='git commit --verbose'
   alias ${gprefix}ca='git commit --verbose --all'
-  alias ${gprefix}cm='git commit --message'
   alias ${gprefix}cA='git commit --patch'
+  alias ${gprefix}cm='git commit --message'
   alias ${gprefix}co='git checkout'
   alias ${gprefix}cO='git checkout --patch'
   alias ${gprefix}cf='git commit --amend --reuse-message HEAD'

--- a/init.zsh
+++ b/init.zsh
@@ -39,6 +39,7 @@ _git_log_oneline_medium_format='%C(bold yellow)%h%C(reset) %<(50,trunc)%s %C(bol
   alias ${gprefix}c='git commit --verbose'
   alias ${gprefix}ca='git commit --verbose --all'
   alias ${gprefix}cm='git commit --message'
+  alias ${gprefix}cA='git commit --patch'
   alias ${gprefix}co='git checkout'
   alias ${gprefix}cO='git checkout --patch'
   alias ${gprefix}cf='git commit --amend --reuse-message HEAD'


### PR DESCRIPTION
I use `git commit --patch` *a lot* and only found an alias for `git add --patch`.

Feel free to tweak the alias if necessary.