### PR TITLE
Add worktree aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ Aliases
   * `Gwx` removes files from the working tree and from the index (recursively).
   * `GwX` removes files from the working tree and from the index (recursively and forced).
 
+### Managing multiple working trees
+
+  * `GW` handle working trees.
+  * `GWa` adds a new working tree.
+  * `GWl` lists current working trees.
+  * `GWm` moves a working tree to a new location.
+  * `GWp` prunes working tree information.
+  * `GWx` removes working tree.
+  * `GWx` removes working tree (forced).
+
 ### Misc
 
   * `G..` changes the current directory to the top level of the working tree.

--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ Aliases
   * `Gtv` verifies the GPG signature of tags.
   * `Gtx` deletes tags with given names.
 
-### Working tree
+### Main working tree
 
-  * `Gws` displays working-tree status in the short format.
-  * `GwS` displays working-tree status.
+  * `Gws` displays working tree status in the short format.
+  * `GwS` displays working tree status.
   * `Gwd` displays changes between the working tree and the index (diff).
   * `GwD` displays changes between the working tree and the index (word diff).
   * `Gwr` resets the current *HEAD* to the specified state, does not touch the index nor the working tree.
@@ -204,15 +204,14 @@ Aliases
   * `Gwx` removes files from the working tree and from the index (recursively).
   * `GwX` removes files from the working tree and from the index (recursively and forced).
 
-### Managing multiple working trees
+### Working trees
 
-  * `GW` handle working trees.
-  * `GWa` adds a new working tree.
-  * `GWl` lists current working trees.
+  * `GW` manages multiple working trees.
+  * `GWa` creates path with a new working tree.
+  * `GWl` lists details of all working trees.
   * `GWm` moves a working tree to a new location.
   * `GWp` prunes working tree information.
-  * `GWx` removes working tree.
-  * `GWx` removes working tree (forced).
+  * `GWx` removes a working tree.
 
 ### Misc
 

--- a/init.zsh
+++ b/init.zsh
@@ -194,6 +194,15 @@ alias ${gprefix}wM='git mv -f'
 alias ${gprefix}wx='git rm -r'
 alias ${gprefix}wX='git rm -rf'
 
+# Managing multiple working trees (W)
+alias ${gprefix}W='git worktree'
+alias ${gprefix}Wa='git worktree add'
+alias ${gprefix}Wl='git worktree list'
+alias ${gprefix}Wm='git worktree move'
+alias ${gprefix}Wp='git worktree prune'
+alias ${gprefix}Wx='git worktree remove'
+alias ${gprefix}WX='git worktree remove --force'
+
 # Misc
 alias ${gprefix}..='cd "$(git-root || print .)"'
 alias ${gprefix}\?="git-alias-lookup ${gmodule_home}"

--- a/init.zsh
+++ b/init.zsh
@@ -180,7 +180,7 @@ alias ${gprefix}ts='git tag --sign'
 alias ${gprefix}tv='git verify-tag'
 alias ${gprefix}tx='git tag --delete'
 
-# Working tree (w)
+# Main working tree (w)
 alias ${gprefix}ws='git status --short'
 alias ${gprefix}wS='git status'
 alias ${gprefix}wd='git diff --no-ext-diff'
@@ -194,14 +194,13 @@ alias ${gprefix}wM='git mv -f'
 alias ${gprefix}wx='git rm -r'
 alias ${gprefix}wX='git rm -rf'
 
-# Managing multiple working trees (W)
+# Working trees (W)
 alias ${gprefix}W='git worktree'
 alias ${gprefix}Wa='git worktree add'
 alias ${gprefix}Wl='git worktree list'
 alias ${gprefix}Wm='git worktree move'
 alias ${gprefix}Wp='git worktree prune'
 alias ${gprefix}Wx='git worktree remove'
-alias ${gprefix}WX='git worktree remove --force'
 
 # Misc
 alias ${gprefix}..='cd "$(git-root || print .)"'


### PR DESCRIPTION
This PR adds one alias for `git worktree`. I think the `Gwt` or `gwt` makes sense - but if you have any better ideas I'm happy to change this.