### PR TITLE
Add `Gtl` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Aliases
 ### Tag
 
   * `Gt` creates, lists, deletes or verifies a tag object signed with GPG.
+  * `Gtl` lists tags in reverse chronological order (by commit date).
   * `Gts` creates a GPG-signed tag.
   * `Gtv` verifies the GPG signature of tags.
   * `Gtx` deletes tags with given names.

--- a/init.zsh
+++ b/init.zsh
@@ -184,6 +184,7 @@ alias ${gprefix}Sx='git-submodule-remove'
 
 # Tag (t)
 alias ${gprefix}t='git tag'
+alias ${gprefix}tl='git tag --list --sort=-committerdate'
 alias ${gprefix}ts='git tag --sign'
 alias ${gprefix}tv='git verify-tag'
 alias ${gprefix}tx='git tag --delete'


### PR DESCRIPTION
This PR adds an alias `Gtl` (git tag list), which lists tags in reverse chronological order using the commit date.

- [x] I've followed Zim's [code style guidelines](https://github.com/zimfw/zimfw/wiki/Code-Style-Guide).
