### PR TITLE
Add common git pull (pl) scripts

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -141,6 +141,13 @@ alias ${gprefix}pt='git push --tags'
 alias ${gprefix}pc='git push --set-upstream origin "$(git-branch-current 2>/dev/null)"'
 alias ${gprefix}pp='git pull origin "$(git-branch-current 2>/dev/null)" && git push origin "$(git-branch-current 2>/dev/null)"'
 
+# Pull (pl)
+alias ${gprefix}pl='git pull'
+alias ${gprefix}plr='git pull --rebase'
+alias ${gprefix}plf='git pull --ff-only'
+alias ${gprefix}pla='git pull --all'
+alias ${gprefix}plp='git pull --prune'
+
 # Rebase (r)
 alias ${gprefix}r='git rebase'
 alias ${gprefix}ra='git rebase --abort'


### PR DESCRIPTION
I know this breaks away from the one-character convention, but I've always had a `gpl` alias available, and I'd really enjoy it if this plugin did as well. 

If it's too divergent from the standard, I understand entirely; I thought I'd try.

I didn't realize until making this pr that the pull scripts were under the fetch "namespace" (f). This isn't intuitive to me.